### PR TITLE
Add score and edge spawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vampire Survivor
 
-This repository contains a basic project setup for a simple Vampire Survivor style game written in Python using Pygame.
+This repository contains a basic project setup for a simple Vampire Survivor style game written in Python using Pygame.  It is a very small MVP where enemies spawn over time and the player automatically fires small bullets.
 
 ## Directory structure
 
@@ -23,3 +23,8 @@ Run the game:
 ```bash
 python src/main.py
 ```
+
+Use the arrow keys to move the player.  Enemies spawn from the edges of the
+screen and chase you while bullets are fired automatically.  Each defeated enemy
+adds to your score displayed in the corner.  Colliding with an enemy ends the
+game.

--- a/src/game/bullet.py
+++ b/src/game/bullet.py
@@ -1,0 +1,14 @@
+import pygame
+
+class Bullet(pygame.sprite.Sprite):
+    def __init__(self, position, speed=10):
+        super().__init__()
+        self.image = pygame.Surface((10, 10))
+        self.image.fill((0, 255, 0))
+        self.rect = self.image.get_rect(center=position)
+        self.speed = speed
+
+    def update(self):
+        self.rect.y -= self.speed
+        if self.rect.bottom < 0:
+            self.kill()

--- a/src/game/enemy.py
+++ b/src/game/enemy.py
@@ -2,14 +2,20 @@ import pygame
 
 
 class Enemy(pygame.sprite.Sprite):
-    def __init__(self, position):
+    def __init__(self, position, speed=2):
         super().__init__()
         self.image = pygame.Surface((40, 40))
         self.image.fill((0, 0, 255))
         self.rect = self.image.get_rect(center=position)
+        self.speed = speed
 
-    def update(self):
-        pass
+    def update(self, target_pos):
+        """Move toward the given target position."""
+        direction = pygame.math.Vector2(target_pos) - self.rect.center
+        if direction.length() != 0:
+            direction = direction.normalize() * self.speed
+            self.rect.centerx += int(direction.x)
+            self.rect.centery += int(direction.y)
 
     def draw(self, surface):
         surface.blit(self.image, self.rect)

--- a/src/game/player.py
+++ b/src/game/player.py
@@ -19,5 +19,8 @@ class Player(pygame.sprite.Sprite):
         if keys[pygame.K_DOWN]:
             self.rect.y += 5
 
+        # Keep player on screen
+        self.rect.clamp_ip(pygame.Rect(0, 0, 800, 600))
+
     def draw(self, surface):
         surface.blit(self.image, self.rect)

--- a/src/game/utils.py
+++ b/src/game/utils.py
@@ -1,0 +1,7 @@
+import pygame
+
+
+def handle_bullet_enemy_collisions(bullets, enemies):
+    """Handle bullet/enemy collisions and return number of enemies removed."""
+    collisions = pygame.sprite.groupcollide(bullets, enemies, True, True)
+    return sum(len(v) for v in collisions.values())

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,9 @@
+import random
 import pygame
 from game.player import Player
+from game.enemy import Enemy
+from game.bullet import Bullet
+from game.utils import handle_bullet_enemy_collisions
 
 
 def main():
@@ -7,20 +11,72 @@ def main():
     screen = pygame.display.set_mode((800, 600))
     pygame.display.set_caption("Vampire Survivor")
     clock = pygame.time.Clock()
+
     player = Player()
+    player_group = pygame.sprite.GroupSingle(player)
+    enemies = pygame.sprite.Group()
+    bullets = pygame.sprite.Group()
+
+    font = pygame.font.SysFont(None, 36)
+    score = 0
+
+    enemy_spawn_event = pygame.USEREVENT + 1
+    bullet_spawn_event = pygame.USEREVENT + 2
+    pygame.time.set_timer(enemy_spawn_event, 1000)
+    pygame.time.set_timer(bullet_spawn_event, 500)
 
     running = True
     while running:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
+            elif event.type == enemy_spawn_event:
+                edge = random.choice(["top", "bottom", "left", "right"])
+                if edge == "top":
+                    position = (
+                        random.randint(0, screen.get_width()),
+                        -20,
+                    )
+                elif edge == "bottom":
+                    position = (
+                        random.randint(0, screen.get_width()),
+                        screen.get_height() + 20,
+                    )
+                elif edge == "left":
+                    position = (
+                        -20,
+                        random.randint(0, screen.get_height()),
+                    )
+                else:
+                    position = (
+                        screen.get_width() + 20,
+                        random.randint(0, screen.get_height()),
+                    )
+                enemies.add(Enemy(position))
+            elif event.type == bullet_spawn_event:
+                bullets.add(Bullet(player.rect.center))
 
         screen.fill((0, 0, 0))
-        player.update()
-        player.draw(screen)
+        player_group.update()
+        enemies.update(player.rect.center)
+        bullets.update()
+
+        score += handle_bullet_enemy_collisions(bullets, enemies)
+
+        if pygame.sprite.spritecollide(player, enemies, False):
+            running = False
+
+        player_group.draw(screen)
+        enemies.draw(screen)
+        bullets.draw(screen)
+
+        score_surf = font.render(f"Score: {score}", True, (255, 255, 255))
+        screen.blit(score_surf, (10, 10))
+
         pygame.display.flip()
         clock.tick(60)
 
+    print(f"Game over! Score: {score}")
     pygame.quit()
 
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,33 @@
+import os
+import sys
+os.environ['SDL_VIDEODRIVER'] = 'dummy'
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+import pygame
+pygame.init()
+
+from game.bullet import Bullet
+from game.enemy import Enemy
+from game.utils import handle_bullet_enemy_collisions
+
+
+def test_bullet_moves_up():
+    b = Bullet((10, 10), speed=5)
+    initial_y = b.rect.y
+    b.update()
+    assert b.rect.y == initial_y - 5
+
+
+def test_enemy_moves_toward_target():
+    e = Enemy((0, 0), speed=2)
+    e.update((3, 0))
+    assert e.rect.centerx > 0
+
+
+def test_collision_returns_score_increment():
+    bullets = pygame.sprite.Group(Bullet((0, 0)))
+    enemies = pygame.sprite.Group(Enemy((0, 0)))
+    killed = handle_bullet_enemy_collisions(bullets, enemies)
+    assert killed == 1
+
+
+pygame.quit()


### PR DESCRIPTION
## Summary
- add score tracking and display
- spawn enemies from screen edges
- print final score on exit
- share collision util to return number killed
- test score increment

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fb772f0d8832d86bb086a5c505a1c