### PR TITLE
Add rapid fire power-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Pink power-ups activate a triple-shot mode letting you fire three bullets at onc
 Light-blue power-ups slow all enemies for a few seconds, displayed with its own timer.
 Purple power-ups let your bullets pierce through enemies for a few seconds.
 Gold power-ups cause bullets to home in on the nearest enemy for a short time, letting you attack foes in any direction.
+Silver power-ups temporarily increase the speed of your bullets, displayed with its own timer.
 
 
 Enemy spawn frequency increases slightly as you rack up kills, but the game is

--- a/src/game/player.py
+++ b/src/game/player.py
@@ -15,6 +15,7 @@ class Player(pygame.sprite.Sprite):
         self.freeze_timer = 0
         self.pierce_timer = 0
         self.homing_timer = 0
+        self.bullet_speed_timer = 0
         self.base_speed = base_speed
 
     def take_damage(self, amount=1):
@@ -41,6 +42,10 @@ class Player(pygame.sprite.Sprite):
 
     def add_homing(self, duration=180):
         self.homing_timer = duration
+
+    def add_bullet_speed(self, duration=180):
+        """Increase bullet speed for a short time."""
+        self.bullet_speed_timer = duration
 
 
 
@@ -71,6 +76,8 @@ class Player(pygame.sprite.Sprite):
             self.pierce_timer -= 1
         if self.homing_timer > 0:
             self.homing_timer -= 1
+        if self.bullet_speed_timer > 0:
+            self.bullet_speed_timer -= 1
 
 
     def draw(self, surface):

--- a/src/game/powerup.py
+++ b/src/game/powerup.py
@@ -65,3 +65,12 @@ class HomingPowerUp(PowerUp):
         self.image.fill((255, 215, 0))
         self.homing_duration = duration
 
+
+class RapidFirePowerUp(PowerUp):
+    """Power-up that increases bullet speed for a short time."""
+
+    def __init__(self, position, duration=180):
+        super().__init__(position, heal_amount=0)
+        self.image.fill((192, 192, 192))
+        self.bullet_speed_duration = duration
+

--- a/src/game/utils.py
+++ b/src/game/utils.py
@@ -55,6 +55,9 @@ def handle_player_powerup_collisions(player, powerups):
         if hasattr(powerup, "homing_duration"):
             player.add_homing(powerup.homing_duration)
             collected = True
+        if hasattr(powerup, "bullet_speed_duration"):
+            player.add_bullet_speed(powerup.bullet_speed_duration)
+            collected = True
 
 
     return collected

--- a/src/main.py
+++ b/src/main.py
@@ -12,6 +12,7 @@ from game.powerup import (
 
     PiercePowerUp,
     HomingPowerUp,
+    RapidFirePowerUp,
 )
 
 from game.utils import (
@@ -86,7 +87,8 @@ def main():
                 else:
                     enemies.add(Enemy(position))
             elif not paused and event.type == bullet_spawn_event:
-                bullet_kwargs = {"piercing": player.pierce_timer > 0}
+                bullet_speed = 15 if player.bullet_speed_timer > 0 else 10
+                bullet_kwargs = {"piercing": player.pierce_timer > 0, "speed": bullet_speed}
                 direction = (0, -1)
                 if player.homing_timer > 0 and len(enemies) > 0:
                     player_pos = pygame.math.Vector2(player.rect.center)
@@ -128,6 +130,8 @@ def main():
                     powerups.add(FreezePowerUp(position))
                 elif roll < 0.95:
                     powerups.add(PiercePowerUp(position))
+                elif roll < 0.97:
+                    powerups.add(RapidFirePowerUp(position))
                 else:
                     powerups.add(HomingPowerUp(position))
 
@@ -188,6 +192,11 @@ def main():
                 f"Homing: {player.homing_timer // 60}", True, (255, 215, 0)
             )
             screen.blit(homing_surf, (10, 190))
+        if player.bullet_speed_timer > 0:
+            rapid_surf = font.render(
+                f"Rapid: {player.bullet_speed_timer // 60}", True, (192, 192, 192)
+            )
+            screen.blit(rapid_surf, (10, 220))
 
 
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -16,6 +16,7 @@ from game.powerup import (
     FreezePowerUp,
     PiercePowerUp,
     HomingPowerUp,
+    RapidFirePowerUp,
 )
 
 
@@ -128,6 +129,20 @@ def test_homing_powerup_sets_timer():
     powerups = pygame.sprite.Group(HomingPowerUp(player.rect.center, duration=5))
     handle_player_powerup_collisions(player, powerups)
     assert player.homing_timer == 5
+
+
+def test_rapid_fire_powerup_sets_timer():
+    player = Player()
+    powerups = pygame.sprite.Group(RapidFirePowerUp(player.rect.center, duration=6))
+    handle_player_powerup_collisions(player, powerups)
+    assert player.bullet_speed_timer == 6
+
+
+def test_bullets_fired_faster_when_powerup_active():
+    player = Player()
+    player.bullet_speed_timer = 2
+    b = Bullet((0, 0), speed=15 if player.bullet_speed_timer > 0 else 10)
+    assert b.speed == 15
 
 
 def test_piercing_bullet_survives_collision():


### PR DESCRIPTION
## Summary
- add RapidFirePowerUp and bullet speed timer on Player
- spawn the new power-up in the game
- show remaining rapid fire time on HUD
- tests for new power-up
- document feature in README

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`

