### PR TITLE
Add max health power-up feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Light-blue power-ups slow all enemies for a few seconds, displayed with its own 
 Purple power-ups let your bullets pierce through enemies for a few seconds.
 Gold power-ups cause bullets to home in on the nearest enemy for a short time, letting you attack foes in any direction.
 Silver power-ups temporarily increase the speed of your bullets, displayed with its own timer.
+Magenta power-ups permanently raise your maximum health by one and heal you.
 
 
 Enemy spawn frequency increases slightly as you rack up kills, but the game is

--- a/src/game/player.py
+++ b/src/game/player.py
@@ -25,6 +25,11 @@ class Player(pygame.sprite.Sprite):
     def heal(self, amount=1):
         self.health = min(self.health + amount, self.max_health)
 
+    def increase_max_health(self, amount=1):
+        """Increase maximum health and heal the player."""
+        self.max_health += amount
+        self.health = self.max_health
+
     def add_shield(self, duration=180):
         self.shield_timer = duration
 

--- a/src/game/powerup.py
+++ b/src/game/powerup.py
@@ -74,3 +74,11 @@ class RapidFirePowerUp(PowerUp):
         self.image.fill((192, 192, 192))
         self.bullet_speed_duration = duration
 
+
+class MaxHealthPowerUp(PowerUp):
+    """Power-up that permanently increases max health."""
+
+    def __init__(self, position, amount=1):
+        super().__init__(position, heal_amount=0)
+        self.image.fill((255, 0, 255))
+        self.max_health_increase = amount

--- a/src/game/utils.py
+++ b/src/game/utils.py
@@ -58,6 +58,9 @@ def handle_player_powerup_collisions(player, powerups):
         if hasattr(powerup, "bullet_speed_duration"):
             player.add_bullet_speed(powerup.bullet_speed_duration)
             collected = True
+        if hasattr(powerup, "max_health_increase"):
+            player.increase_max_health(powerup.max_health_increase)
+            collected = True
 
 
     return collected

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from game.powerup import (
     FreezePowerUp,
 
     PiercePowerUp,
+    MaxHealthPowerUp,
     HomingPowerUp,
     RapidFirePowerUp,
 )
@@ -132,6 +133,8 @@ def main():
                     powerups.add(PiercePowerUp(position))
                 elif roll < 0.97:
                     powerups.add(RapidFirePowerUp(position))
+                elif roll < 0.98:
+                    powerups.add(MaxHealthPowerUp(position))
                 else:
                     powerups.add(HomingPowerUp(position))
 

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -15,6 +15,7 @@ from game.powerup import (
     TripleShotPowerUp,
     FreezePowerUp,
     PiercePowerUp,
+    MaxHealthPowerUp,
     HomingPowerUp,
     RapidFirePowerUp,
 )
@@ -143,6 +144,14 @@ def test_bullets_fired_faster_when_powerup_active():
     player.bullet_speed_timer = 2
     b = Bullet((0, 0), speed=15 if player.bullet_speed_timer > 0 else 10)
     assert b.speed == 15
+
+
+def test_max_health_powerup_increases_max_and_heals():
+    player = Player(health=3, max_health=5)
+    powerups = pygame.sprite.Group(MaxHealthPowerUp(player.rect.center, amount=1))
+    handle_player_powerup_collisions(player, powerups)
+    assert player.max_health == 6
+    assert player.health == 6
 
 
 def test_piercing_bullet_survives_collision():


### PR DESCRIPTION
## Summary
- introduce `MaxHealthPowerUp` that raises player maximum health
- allow Player to increase max health and heal
- handle new power-up in collision logic
- spawn the new power-up in the main loop
- document new power-up in README
- test the new functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

